### PR TITLE
Fix version retrival

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,18 +30,23 @@ jobs:
       - name: Extract Version
         id: version
         run: echo "version=$(sh get_release_info.sh version)" |tee -a $GITHUB_OUTPUT
+      - name: Extract Version
+        id: skopeo
+        run: echo "list-images=$(skopeo list-tags docker://${{ env.REGISTRY }}/${{ github.repository }})" |tee -a $GITHUB_OUTPUT
+
+
       # - name: Get current date/time in the usual format
       #   id: date
       #   run: echo "::set-output name=date::$(date +'%Y.%m.%d.%H%M%S')"
-      # - name: Env
-      #   id: env
-      #   run: env | tee /tmp/env.txt; cat /tmp/env.txt
+      - name: Env
+        id: env
+        run: echo ${{ steps.skopeo.outputs.list-images }}
       # - name: Get current date/time in the usual format
       #   id: date
       #   run: echo "::set-output name=date::$(date +'%Y.%m.%d.%H%M%S')"
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ github.repository }}:latest, ${{ env.REGISTRY }}/${{ github.repository }}:${{ steps.version.outputs.version }}
+      # - name: Build and push Docker image
+      #   uses: docker/build-push-action@v4
+      #   with:
+      #     context: .
+      #     push: true
+      #     tags: ${{ env.REGISTRY }}/${{ github.repository }}:latest, ${{ env.REGISTRY }}/${{ github.repository }}:${{ steps.version.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,4 +38,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.GITHUB_REPOSITORY }}:latest, ${{ env.REGISTRY }}/${{ env.GITHUB_REPOSITORY }}:${{ steps.date.outputs.version }}
+          tags: ${{ env.REGISTRY }}/${{ vars.GITHUB_REPOSITORY }}:latest, ${{ env.REGISTRY }}/${{ vars.GITHUB_REPOSITORY }}:${{ steps.date.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,9 +33,9 @@ jobs:
       # - name: Get current date/time in the usual format
       #   id: date
       #   run: echo "::set-output name=date::$(date +'%Y.%m.%d.%H%M%S')"
-      - name: Env
-        id: env
-        run: env | tee /tmp/env.txt; cat /tmp/env.txt
+      # - name: Env
+      #   id: env
+      #   run: env | tee /tmp/env.txt; cat /tmp/env.txt
       # - name: Get current date/time in the usual format
       #   id: date
       #   run: echo "::set-output name=date::$(date +'%Y.%m.%d.%H%M%S')"
@@ -44,4 +44,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY }}/${{ github.repository }}:latest, ${{ env.REGISTRY }}/${{ github.repository }}:${{ steps.date.outputs.version }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}:latest, ${{ env.REGISTRY }}/${{ github.repository }}:${{ steps.version.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,4 +44,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY }}/$GITHUB_REPOSITORY:latest, ${{ env.REGISTRY }}/$GITHUB_REPOSITORY:${{ steps.date.outputs.version }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}:latest, ${{ env.REGISTRY }}/${{ github.repository }}:${{ steps.date.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,11 +24,11 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Get current date/time in the usual format
-        id: version
-        run: echo "::set-output name=version::$(sh get_release_info.sh version)"
-
-
+      # - name: Get current date/time in the usual format
+      #   id: version
+      #   run: echo "::set-output name=version::$(sh get_release_info.sh version)"
+      - name: Extract Version
+        run: echo "version=$(sh get_release_info.sh version)" |tee -a $GITHUB_OUTPUT
       # - name: Get current date/time in the usual format
       #   id: date
       #   run: echo "::set-output name=date::$(date +'%Y.%m.%d.%H%M%S')"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,9 +33,15 @@ jobs:
       # - name: Get current date/time in the usual format
       #   id: date
       #   run: echo "::set-output name=date::$(date +'%Y.%m.%d.%H%M%S')"
+      - name: Env
+        id: env
+        run: env | tee /tmp/env.txt; cat /tmp/env.txt
+      # - name: Get current date/time in the usual format
+      #   id: date
+      #   run: echo "::set-output name=date::$(date +'%Y.%m.%d.%H%M%S')"
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY }}/${{ GITHUB_REPOSITORY }}:latest, ${{ env.REGISTRY }}/${{ GITHUB_REPOSITORY }}:${{ steps.date.outputs.version }}
+          tags: ${{ env.REGISTRY }}/$GITHUB_REPOSITORY:latest, ${{ env.REGISTRY }}/$GITHUB_REPOSITORY:${{ steps.date.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,13 +28,14 @@ jobs:
       #   id: version
       #   run: echo "::set-output name=version::$(sh get_release_info.sh version)"
       - name: Extract Version
+        id: version
         run: echo "version=$(sh get_release_info.sh version)" |tee -a $GITHUB_OUTPUT
       # - name: Get current date/time in the usual format
       #   id: date
       #   run: echo "::set-output name=date::$(date +'%Y.%m.%d.%H%M%S')"
-      # - name: Build and push Docker image
-      #   uses: docker/build-push-action@v2
-      #   with:
-      #     context: .
-      #     push: true
-      #     tags: mikeah/cura-novnc:latest,  mikeah/cura-novnc:${{ steps.date.outputs.date }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.GITHUB_REPOSITORY }}:latest, ${{ env.REGISTRY }}/${{ env.GITHUB_REPOSITORY }}:${{ steps.date.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,24 +5,36 @@ on:
     - cron: '0 0 * * 5' # Every Friday at midnight we publish an image from latest to Docker Hub.
   workflow_dispatch:
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Get current date/time in the usual format
-        id: date
-        run: echo "::set-output name=date::$(date +'%Y.%m.%d.%H%M%S')"
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          tags: mikeah/cura-novnc:latest,  mikeah/cura-novnc:${{ steps.date.outputs.date }}
+        id: version
+        run: echo "::set-output name=version::$(sh get_release_info.sh version)"
+
+
+      # - name: Get current date/time in the usual format
+      #   id: date
+      #   run: echo "::set-output name=date::$(date +'%Y.%m.%d.%H%M%S')"
+      # - name: Build and push Docker image
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     context: .
+      #     push: true
+      #     tags: mikeah/cura-novnc:latest,  mikeah/cura-novnc:${{ steps.date.outputs.date }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,4 +38,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY }}/${{ vars.GITHUB_REPOSITORY }}:latest, ${{ env.REGISTRY }}/${{ vars.GITHUB_REPOSITORY }}:${{ steps.date.outputs.version }}
+          tags: ${{ env.REGISTRY }}/${{ GITHUB_REPOSITORY }}:latest, ${{ env.REGISTRY }}/${{ GITHUB_REPOSITORY }}:${{ steps.date.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,12 +26,12 @@ RUN apt update && apt install -y --no-install-recommends --allow-unauthenticated
     && rm -rf /var/lib/apt/lists/*
 
 # Install Cura!
-ADD get_latest_cura_release.sh cura/
+ADD get_release_info.sh cura/
 WORKDIR /cura
 
-RUN chmod +x /cura/get_latest_cura_release.sh \
-  && latestCura=$(/cura/get_latest_cura_release.sh url) \
-  && curaReleaseName=$(/cura/get_latest_cura_release.sh name) \
+RUN chmod +x /cura/get_release_info.sh \
+  && latestCura=$(/cura/get_release_info.sh url) \
+  && curaReleaseName=$(/cura/get_release_info.sh name) \
   && curl -sSL ${latestCura} > ${curaReleaseName} \
   && rm -f /cura/releaseInfo.json \
   && chmod +x /cura/${curaReleaseName} \
@@ -48,15 +48,15 @@ RUN chmod +x /cura/get_latest_cura_release.sh \
   && mkdir -p /prints/ \
   && chown -R cura:cura /cura/ /home/cura/ /prints/ \
   && mkdir -p /home/cura/.config/ \
-  # We can now set the Download directory for Firefox and other browsers. 
+  # We can now set the Download directory for Firefox and other browsers.
   # We can also add /prints/ to the file explorer bookmarks for easy access.
   && echo "XDG_DOWNLOAD_DIR=\"/prints/\"" >> /home/cura/.config/user-dirs.dirs \
-  && echo "file:///prints prints" >> /home/cura/.gtk-bookmarks 
+  && echo "file:///prints prints" >> /home/cura/.gtk-bookmarks
 
 COPY --from=easy-novnc-build /bin/easy-novnc /usr/local/bin/
 COPY menu.xml /etc/xdg/openbox/
 COPY supervisord.conf /etc/
-EXPOSE 8080
+EXPOSE 5900
 
 VOLUME /home/cura/
 VOLUME /prints/

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN chmod +x /cura/get_release_info.sh \
 COPY --from=easy-novnc-build /bin/easy-novnc /usr/local/bin/
 COPY menu.xml /etc/xdg/openbox/
 COPY supervisord.conf /etc/
-EXPOSE 5900
+EXPOSE 8080
 
 VOLUME /home/cura/
 VOLUME /prints/

--- a/get_release_info.sh
+++ b/get_release_info.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+TMPDIR="$(mktemp -d)"
+
+curl -SsL https://api.github.com/repos/Ultimaker/Cura/releases/latest > $TMPDIR/latest.json
+
+url=$(jq -r '.assets[] | select(.browser_download_url|test("-linux.AppImage$"))| .browser_download_url' $TMPDIR/latest.json)
+name=$(jq -r '.assets[] | select(.browser_download_url|test("-linux.AppImage$"))| .name' $TMPDIR/latest.json)
+version=$(jq -r .tag_name $TMPDIR/latest.json)
+
+if [ $# -ne 1 ]; then
+  echo wrong number of params
+  exit 1
+else
+  request=$1
+fi
+
+case $request in
+
+  url)
+    echo $url
+    ;;
+
+  name)
+    echo $name
+    ;;
+
+  version)
+    echo $version
+    ;;
+
+  *)
+    echo "Unknown request"
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
I've simplified the script as the release format has changed during time.
It now fetches the version correctly.
I won't touch your GitHub workflow but if you want you can use it to check the latest available tag versus your latest tagged container mirroring the correct tag instead of using a date. More simple to apply and less dirty IMHO :)
If you want I can provide a PR for that too.