### PR TITLE
New workflow to auto release new cura images via tag matching

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,13 @@
-name: Publish to Docker
+name: Build New Version
 
 on:
   schedule:
-    - cron: '0 0 * * 5' # Every Friday at midnight we publish an image from latest to Docker Hub.
-  workflow_dispatch:
+    - cron: 0 0 * * 5
+  workflow_dispatch: {}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   push_to_registry:
@@ -11,18 +15,38 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Get current date/time in the usual format
-        id: date
-        run: echo "::set-output name=date::$(date +'%Y.%m.%d.%H%M%S')"
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract latest available Cura Version
+        id: version
+        run: echo "version=$(sh get_release_info.sh version)" |tee -a $GITHUB_OUTPUT
+
+      - name: Check if this release already exists
+        uses: mukunku/tag-exists-action@v1.2.0
+        id: checktag
+        with:
+          tag: ${{ steps.version.outputs.version }}
+
+      - name: Create new tag with Cura Version
+        uses: rickstaa/action-create-tag@v1
+        id: tag_create
+        if: ${{ steps.checktag.outputs.exists == 'false' }}
+        with:
+          tag: ${{ steps.version.outputs.version }}
+          tag_exists_error: false
+          message: New Cura Release ${{ steps.version.outputs.version }}
+
+      - name: Build and push Container
+        uses: docker/build-push-action@v4
+        if: ${{ steps.checktag.outputs.exists == 'false' }}
         with:
           context: .
           push: true
-          tags: mikeah/cura-novnc:latest,  mikeah/cura-novnc:${{ steps.date.outputs.date }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}:latest, ${{ env.REGISTRY }}/${{ github.repository }}:${{ steps.version.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,8 +21,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract latest available Cura Version
         id: version

--- a/get_release_info.sh
+++ b/get_release_info.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+TMPDIR="$(mktemp -d)"
+
+curl -SsL https://api.github.com/repos/Ultimaker/Cura/releases/latest > $TMPDIR/latest.json
+
+url=$(jq -r '.assets[] | select(.browser_download_url|test("-linux.AppImage$"))| .browser_download_url' $TMPDIR/latest.json)
+name=$(jq -r '.assets[] | select(.browser_download_url|test("-linux.AppImage$"))| .name' $TMPDIR/latest.json)
+version=$(jq -r .tag_name $TMPDIR/latest.json)
+
+if [ $# -ne 1 ]; then
+  echo wrong number of params
+  exit 1
+else
+  request=$1
+fi
+
+case $request in
+
+  url)
+    echo $url
+    ;;
+
+  name)
+    echo $name
+    ;;
+
+  version)
+    echo $version
+    ;;
+
+  *)
+    echo "Unknown request"
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
This workflow check the latest Cura version and build a matching image with same release tag. It also create a new tag in the repository.
I moved the workflow to release on ghcr.io instead docker.io as I don't use Docker.io anymore but you get the idea.
