### PR TITLE
Adding openscad to the toolbox availible to cura(plugins) by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -y && \
 
 # Get all of the remaining dependencies for the OS, VNC, and Cura (additionally Firefox-ESR to sign-in to Ultimaker if you'd like).
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends lxterminal nano wget openssh-client rsync ca-certificates xdg-utils htop tar xzip gzip bzip2 zip unzip && \
+    apt-get install -y --no-install-recommends openscad lxterminal nano wget openssh-client rsync ca-certificates xdg-utils htop tar xzip gzip bzip2 zip unzip && \
     rm -rf /var/lib/apt/lists
 
 RUN apt update && apt install -y --no-install-recommends --allow-unauthenticated \


### PR DESCRIPTION
Added the openscad dependency to enable the custom temperature towers that can be generated with the help of the Cura "Auto towers" plugin.
Openscad is required to automatically generate temperature towers with custom parameters which can be quite useful for fine tuning and special types of filaments and or printers. 

Openscad Project: https://openscad.org/index.html
Auto Towers Plugin for cura: https://marketplace.ultimaker.com/app/cura/plugins/Kartchnb/AutoTowersGenerator